### PR TITLE
refactor: feature gating

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,14 +158,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "std")]
 mod parse;
 
-#[cfg(not(feature = "std"))]
-use core::ops::{Div, Neg};
-
-#[cfg(feature = "std")]
-use std::{
+use core::{
     fmt,
     ops::{Div, Neg},
 };
@@ -330,7 +325,6 @@ impl<F: Amounts> NumberPrefix<F> {
     }
 }
 
-#[cfg(feature = "std")]
 impl fmt::Display for Prefix {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.symbol())

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, fmt, str};
+use core::{fmt, str};
 
 use super::{NumberPrefix, Prefix};
 
@@ -55,8 +55,8 @@ impl fmt::Display for NumberPrefixParseError {
     }
 }
 
-impl Error for NumberPrefixParseError {}
-
+#[cfg(feature = "std")]
+impl std::error::Error for NumberPrefixParseError {}
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
`fmt::Display` and `str::FromStr` are actually available in `core`.

This does not change the MSRV:
```console
$ cargo msrv verify -- cargo build-all-features
Fetching index
Verifying the Minimum Supported Rust Version (MSRV) for toolchain x86_64-unknown-linux-gnu
Using check command cargo build-all-features
   Finished Satisfied MSRV check: 1.31.1 
```